### PR TITLE
Update version numbers in examples to 1.4.0

### DIFF
--- a/_documentation/circleci.md
+++ b/_documentation/circleci.md
@@ -99,7 +99,7 @@ To run our Interoperability Tests, only one step needs to be added to this. This
 {% highlight yaml %}
 
   orbs:
-    xmpp-interop-tests: xmpp-interop-tests/tests@1.0.0
+    xmpp-interop-tests: xmpp-interop-tests/tests@1.4.0
 
 {% endhighlight %}
 
@@ -128,7 +128,7 @@ usage:
   version: 2.1
 
   orbs:
-    xmpp-interop-tests: xmpp-interop-tests/tests@1.0.0
+    xmpp-interop-tests: xmpp-interop-tests/tests@1.4.0
 
   jobs:
     build:

--- a/_documentation/github.md
+++ b/_documentation/github.md
@@ -17,7 +17,7 @@ Assuming that you have a pre-existing pipeline that build your server and starts
 {% highlight yaml %}
 
 - name: Run XMPP Interoperability Tests against CI server.
-  uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.0
+  uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.4.0
   with:
     domain: 'shakespeare.lit'
     adminAccountUsername: 'juliet'
@@ -94,7 +94,7 @@ To run our Interoperability Tests, only one step needs to be added to this:
 {% highlight yaml %}
 
       - name: Run XMPP Interoperability Tests against CI server.
-        uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.2
+        uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.4.0
         with:
           domain: 'shakespeare.lit'
           adminAccountUsername: 'juliet'
@@ -149,7 +149,7 @@ jobs:
         run: ./ci-scripts/execute-tests # Run tests that already existed in your pipeline
 
       - name: Run XMPP Interoperability Tests against CI server
-        uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.0
+        uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.4.0
         with:
           domain: 'shakespeare.lit'
           adminAccountUsername: 'juliet'

--- a/_documentation/gitlab.md
+++ b/_documentation/gitlab.md
@@ -17,7 +17,7 @@ Assuming you already have a pipeline, and a script to launch your server, adding
 {% highlight yaml %}
 
   include:
-    - component: gitlab.com/xmpp-interop-testing/xmpp-interop-testing-gitlab-component/interop-testing@v1.3.2
+    - component: gitlab.com/xmpp-interop-testing/xmpp-interop-testing-gitlab-component/interop-testing@v1.4.0
       inputs:
         domain: 'shakespeare.lit'
         adminAccountUsername: 'juliet'
@@ -65,7 +65,7 @@ Then you'd add our first example, with tweaks for dependencies and for launching
         - my_xmpp_server
 
   include:
-    - component: gitlab.com/xmpp-interop-testing/xmpp-interop-testing-gitlab-component/interop-testing@v1.3.2
+    - component: gitlab.com/xmpp-interop-testing/xmpp-interop-testing-gitlab-component/interop-testing@v1.4.0
       inputs:
         domain: 'shakespeare.lit'
         host: '127.0.0.1'


### PR DESCRIPTION
Bump up the version numbers that are used in example snippets to use the latest release (1.4.0)