### PR TITLE
Be more verbose about different provisioning options

### DIFF
--- a/_documentation/circleci.md
+++ b/_documentation/circleci.md
@@ -24,8 +24,7 @@ Assuming that you have a pre-existing pipeline that build your server and starts
 
 {% endhighlight %}
 
-
-The above assumes that your server is running and reachable on the domain `shakespeare.lit` and that it is provisioned with an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. You'll find the full range of available configuration options below.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and accessible at `shakespeare.lit`, and that it already has an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. Other configuration methods are also available, and you can explore the full set of options in the sections below.
 
 ## A Full Example
 

--- a/_documentation/docker.md
+++ b/_documentation/docker.md
@@ -25,7 +25,7 @@ docker run \
     --adminAccountPassword=O_Romeo_Romeo
 {% endhighlight %}
 
-The above assumes that your server is running and reachable on the domain `shakespeare.lit` and that it is provisioned with an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. You'll find the full range of available configuration options below.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and accessible at `shakespeare.lit`, and that it already has an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. Other configuration methods are also available, and you can explore the full set of options in the sections below.
 
 ## Configuration
 

--- a/_documentation/drone.md
+++ b/_documentation/drone.md
@@ -24,7 +24,7 @@ Assuming that you have a pre-existing pipeline that build your server and starts
 
 {% endhighlight %}
 
-The above assumes that your server is running and reachable on the host `xmppserver`, serving the XMPP domain `shakespeare.lit`. You'll find the full range of available configuration options below.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and reachable on the host `xmppserver`, serving the XMPP domain `shakespeare.lit`, and that it supports In-Band Registration (as defined in [XEP-0077](https://xmpp.org/extensions/xep-0077.html)) to provision accounts. Other configuration methods are also available, and you can explore the full set of options in the sections below.
 
 ## A Full Example
 

--- a/_documentation/forgejo.md
+++ b/_documentation/forgejo.md
@@ -25,7 +25,7 @@ Assuming that you have a pre-existing pipeline that build your server and starts
 
 {% endhighlight %}
 
-The above assumes that your server is running and reachable on the domain `shakespeare.lit` and that it is provisioned with an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. You'll find the full range of available configuration options below.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and accessible at `shakespeare.lit`, and that it already has an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. Other configuration methods are also available, and you can explore the full set of options in the sections below.
 
 ## A Full Example
 

--- a/_documentation/github.md
+++ b/_documentation/github.md
@@ -25,8 +25,7 @@ Assuming that you have a pre-existing pipeline that build your server and starts
 
 {% endhighlight %}
 
-
-The above assumes that your server is running and reachable on the domain `shakespeare.lit` and that it is provisioned with an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. You'll find the full range of available configuration options below.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and accessible at `shakespeare.lit`, and that it already has an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. Other configuration methods are also available, and you can explore the full set of options in the sections below.
 
 ## A Full Example
 

--- a/_documentation/gitlab.md
+++ b/_documentation/gitlab.md
@@ -29,7 +29,7 @@ Assuming you already have a pipeline, and a script to launch your server, adding
 
 {% endhighlight %}
 
-The above assumes that when your server runs is running and reachable on the domain `shakespeare.lit` and that it is provisioned with an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. You'll find the full range of available configuration options below.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and accessible at `shakespeare.lit`, and that it already has an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. Other configuration methods are also available, and you can explore the full set of options in the sections below.
 
 ## A Full Example
 

--- a/_documentation/harness.md
+++ b/_documentation/harness.md
@@ -31,7 +31,7 @@ Assuming that you have a pre-existing pipeline that build your server and starts
 
 {% endhighlight %}
 
-The above assumes that your server is running and reachable on the host `xmppserver`, serving the XMPP domain `shakespeare.lit`. You'll find the full range of available configuration options below.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and reachable on the host `xmppserver`, serving the XMPP domain `shakespeare.lit`, and that it supports In-Band Registration (as defined in [XEP-0077](https://xmpp.org/extensions/xep-0077.html)) to provision accounts. Other configuration methods are also available, and you can explore the full set of options in the sections below.
 
 ## A Full Example
 

--- a/_documentation/jenkins.md
+++ b/_documentation/jenkins.md
@@ -28,7 +28,7 @@ stage('test-server') {
 
 {% endhighlight %}
 
-The above assumes that when your server runs is running and reachable on the domain `shakespeare.lit` and that it is provisioned with an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and accessible at `shakespeare.lit`, and that it already has an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. Other configuration methods are also available.
 
 For the full list of options available to the docker image, including how to persist logs, limit the scope of the tests, or explicitly set a host rather than relying on DNS, see the [Docker](/documentation/docker) instructions.
 

--- a/_documentation/podman.md
+++ b/_documentation/podman.md
@@ -25,7 +25,7 @@ podman run \
     --adminAccountPassword=O_Romeo_Romeo
 {% endhighlight %}
 
-The above assumes that your server is running and reachable on the domain `shakespeare.lit` and that it is provisioned with an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. You'll find the full range of available configuration options below.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and accessible at `shakespeare.lit`, and that it already has an administrative account (one that is allowed to create other users, per [XEP-0133](https://xmpp.org/extensions/xep-0133.html)) that uses the username `juliet` and the provided password. Other configuration methods are also available, and you can explore the full set of options in the sections below.
 
 ## Configuration
 

--- a/_documentation/woodpecker.md
+++ b/_documentation/woodpecker.md
@@ -26,7 +26,7 @@ Assuming that you have a pre-existing pipeline that build your server and starts
 
 {% endhighlight %}
 
-The above assumes that your server is running and reachable on the host `xmppserver`, serving the XMPP domain `shakespeare.lit`. You'll find the full range of available configuration options below.
+This example demonstrates one possible way to provision accounts. It assumes your server is running and reachable on the host `xmppserver`, serving the XMPP domain `shakespeare.lit`, and that it supports In-Band Registration (as defined in [XEP-0077](https://xmpp.org/extensions/xep-0077.html)) to provision accounts. Other configuration methods are also available, and you can explore the full set of options in the sections below.
 
 ## A Full Example
 


### PR DESCRIPTION
From user feedback: people tend to stop reading when they believe they see an incompatibility with their environment.

To prevent that, this commit changes wording of the first example to emphasise that the example shows only one of multiple provisioning options.